### PR TITLE
Fixed useState bug inside for loop

### DIFF
--- a/src/renderer/views/LeaderboardView.tsx
+++ b/src/renderer/views/LeaderboardView.tsx
@@ -16,6 +16,7 @@ export function LeaderboardView() {
     async function load() {
       const data = (await axios.get('https://3speak.tv/apiv2/leaderboard')).data
       let step = 1
+      let bronzeToSet = [];
       for (const ex of data) {
         if (step >= 30) {
           break
@@ -27,10 +28,11 @@ export function LeaderboardView() {
         } else if (step === 3) {
           setThird(ex)
         } else {
-          setBronze([...bronze, ex])
+          bronzeToSet.push(ex);
         }
         step++
       }
+      setBronze(bronzeToSet);
     }
   }, [])
 


### PR DESCRIPTION
When you use the spread operator and the setstate inside a for loop it can behave in unexpected ways. It was fixed by using a temporary array to store the items, and then calling the set state one single time, to avoid sync issues because of the for loop.