### PR TITLE
Fix encoder crashing in development mode

### DIFF
--- a/src/main/core/components/EncoderService.ts
+++ b/src/main/core/components/EncoderService.ts
@@ -7,11 +7,11 @@ import fs from 'fs'
 import { uuidv4 } from 'uuid'
 import { globSource } from 'ipfs-http-client'
 import { EventEmitter } from 'events'
-//import { path as ffmpegPath } from '@ffmpeg-installer/ffmpeg'
+import { path as ffmpegPath } from '@ffmpeg-installer/ffmpeg'
 import { GetFfmpegPath } from '../ffmpeg_helper'
 
 if (process.env.NODE_ENV === 'development') {
-  //ffmpeg.setFfmpegPath(ffmpegPath)
+  ffmpeg.setFfmpegPath(ffmpegPath)
 } else {
   try {
     ffmpeg.setFfmpegPath(GetFfmpegPath())

--- a/src/main/core/components/EncoderService.ts
+++ b/src/main/core/components/EncoderService.ts
@@ -7,17 +7,13 @@ import fs from 'fs'
 import { uuidv4 } from 'uuid'
 import { globSource } from 'ipfs-http-client'
 import { EventEmitter } from 'events'
-import { path as ffmpegPath } from '@ffmpeg-installer/ffmpeg'
+// import { path as ffmpegPath } from '@ffmpeg-installer/ffmpeg'
 import { GetFfmpegPath } from '../ffmpeg_helper'
 
-if (process.env.NODE_ENV === 'development') {
-  ffmpeg.setFfmpegPath(ffmpegPath)
-} else {
-  try {
-    ffmpeg.setFfmpegPath(GetFfmpegPath())
-  } catch (ex) {
-    console.error(`Error getting ffmpeg path for production`)
-  }
+try {
+  ffmpeg.setFfmpegPath(GetFfmpegPath())
+} catch (ex) {
+  console.error(`Error getting ffmpeg path for production`)
 }
 
 const MAX_BIT_RATE = {

--- a/src/renderer/views/UploaderView.tsx
+++ b/src/renderer/views/UploaderView.tsx
@@ -25,10 +25,12 @@ export function UploaderView() {
   const thumbnailUpload = useRef<any>()
   const thumbnailPreview = useRef('')
   const publishForm = useRef()
-  const hwaccelOption = useRef()
+  // const hwaccelOption = useRef()
   const ipfs = useRef<any>()
 
   const [logData, setLogData] = useState([])
+  const [hwaccelOption, setHwaccelOption] = useState('')
+
   const [videoSourceFile, setVideoSourceFile] = useState()
   const [encodingInProgress, setEncodingInProgress] = useState(false)
   const [progress, setProgress] = useState<any>({})
@@ -229,8 +231,12 @@ export function UploaderView() {
       ],
       options: {
         hwaccel:
-          hwaccelOption.current !== '' && hwaccelOption.current !== 'none'
-            ? hwaccelOption.current
+          hwaccelOption &&
+          hwaccelOption.length > 0 &&
+          hwaccelOption !== '' &&
+          hwaccelOption &&
+          hwaccelOption !== 'none'
+            ? hwaccelOption
             : undefined,
       },
     } as any)) as any
@@ -477,7 +483,8 @@ export function UploaderView() {
                   </Form.Text>
                   <select
                     style={{ width: '6em' }}
-                    ref={hwaccelOption}
+                    value={hwaccelOption}
+                    onChange={(e) => setHwaccelOption(e.target.value)}
                     disabled={encodingInProgress}
                     id="language"
                     className="form-control mb-4"


### PR DESCRIPTION
The encoding, when uploading a video, was crashing when running in development mode (locally). It is fixed by fixing the hardware accelerator state (the object wasn't matching the conditions, now it is simply a string and the checks can be met) and by using the same ffmpeg path in development as in non-development mode