### PR TITLE
add rehype-raw to parse HTML content

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "react-notifications": "^1.7.2",
     "react-popup": "^0.10.0",
     "react-router-dom": "^5.2.0",
+    "rehype-raw": "^6.1.1",
     "tedious": "^14.0.0",
     "wa-go-ipfs": "git+https://github.com/vaultec81/wa-go-ipfs.git",
     "winston": "^3.3.3",

--- a/src/renderer/views/WatchView/WatchViewContent.tsx
+++ b/src/renderer/views/WatchView/WatchViewContent.tsx
@@ -11,6 +11,7 @@ import { Player } from '../../components/video/Player'
 import { LoopCircleLoading } from 'react-loadingg'
 import DateTime from 'date-and-time'
 import DOMPurify from 'dompurify'
+import rehypeRaw from 'rehype-raw'
 export const WatchViewContent = (props: any) => {
   const {
     loaded,
@@ -127,7 +128,7 @@ export const WatchViewContent = (props: any) => {
               <div className="single-video-info-content box mb-3">
                 <h6>About :</h6>
                 <CollapsibleText>
-                  <ReactMarkdown skipHtml={false}>
+                  <ReactMarkdown rehypePlugins={[rehypeRaw]}>
                     {DOMPurify.sanitize(videoInfo.description)}
                   </ReactMarkdown>
                   <hr />


### PR DESCRIPTION
HTML rendering on the "about" section of videos is fixed. The usage of `DOMPurify.sanitize` plus `rehypeRaw` seems to make the rendering safe