### PR TITLE
Feat/storage path chosen by user

### DIFF
--- a/src/main/core/components/ipfsHandler.ts
+++ b/src/main/core/components/ipfsHandler.ts
@@ -105,10 +105,10 @@ export class IpfsHandler {
       let ipfsPath
       if (folderPath) {
         ipfsPath = folderPath
-        config.set('ipfsPath', folderPath)
       } else {
         ipfsPath = ipfsInfo.ipfsPath // Use the default path if no folder is selected
       }
+      config.set('ipfsPath', ipfsPath)
       await IpfsHandler.init(ipfsPath)
       fs.writeFileSync(Path.join(appPath, 'ipfs.pid'), `${await IpfsHandler.run(ipfsPath)}`)
       IpfsHandler.events.emit('ready')

--- a/src/main/core/components/ipfsHandler.ts
+++ b/src/main/core/components/ipfsHandler.ts
@@ -6,13 +6,14 @@ import * as IPFSHTTPClient from 'ipfs-http-client'
 import { execFile, spawn } from 'child_process'
 import execa from 'execa'
 import { IPFS_HOST, IPFS_SELF_MULTIADDR } from '../../../common/constants'
+import Config from './Config'
+
+const { dialog } = require('electron')
+const Utils = require('../utils')
 const waIpfs = require('wa-go-ipfs')
 const toUri = require('multiaddr-to-uri')
 
-const IPFSPORTS = [
-  '5001',
-  '5004'
-]
+const IPFSPORTS = ['5001', '5004']
 
 const defaultIpfsConfig = {
   API: {
@@ -75,6 +76,21 @@ export class IpfsHandler {
       }
     })
   }
+  static async selectFolderPath() {
+    try {
+      const result = await dialog.showOpenDialog({
+        properties: ['openDirectory'],
+        title: 'Select IPFS folder for 3Speak pins',
+        message: 'Please select a folder to store IPFS data:',
+      })
+
+      const folderPath = result.canceled ? null : result.filePaths[0]
+      return folderPath
+    } catch (error) {
+      console.error(error)
+      return null // Error occurred
+    }
+  }
   static async start(appPath) {
     IpfsHandler.events.once('ready', async () => {
       this.isReady = true
@@ -83,12 +99,18 @@ export class IpfsHandler {
     let ipfsInfo = await IpfsHandler.getIpfs()
     if (!ipfsInfo.exists) {
       console.log(`5`)
-      ipfsInfo = await IpfsHandler.getIpfs()
-      await IpfsHandler.init(ipfsInfo.ipfsPath)
-      fs.writeFileSync(
-        Path.join(appPath, 'ipfs.pid'),
-        `${await IpfsHandler.run(ipfsInfo.ipfsPath)}`,
-      )
+      const config = new Config(Utils.getRepoPath())
+      await config.open()
+      const folderPath = await this.selectFolderPath()
+      let ipfsPath
+      if (folderPath) {
+        ipfsPath = folderPath
+        config.set('ipfsPath', folderPath)
+      } else {
+        ipfsPath = ipfsInfo.ipfsPath // Use the default path if no folder is selected
+      }
+      await IpfsHandler.init(ipfsPath)
+      fs.writeFileSync(Path.join(appPath, 'ipfs.pid'), `${await IpfsHandler.run(ipfsPath)}`)
       IpfsHandler.events.emit('ready')
     } else {
       console.log(`6`)
@@ -116,7 +138,7 @@ export class IpfsHandler {
     const goIpfsPath = await waIpfs.getPath(
       waIpfs.getDefaultPath({ dev: process.env.NODE_ENV === 'development' }),
     )
-    console.log('repoPath', {repoPath, goIpfsPath})
+    console.log('repoPath', { repoPath, goIpfsPath })
     await execa(goIpfsPath, ['init'], {
       env: {
         IPFS_PATH: repoPath,
@@ -166,12 +188,19 @@ export class IpfsHandler {
     })
   }
   static async getIpfs() {
-
     let ipfsPath: string
     if (process.env.IPFS_PATH) {
       ipfsPath = process.env.IPFS_PATH
     } else {
-      ipfsPath = Path.join(os.homedir(), '.ipfs-3speak_v0.16.0')
+      const config = new Config(Utils.getRepoPath())
+      await config.open()
+      let ipfsPathConfig = config.get('ipfsPath')
+
+      if (ipfsPathConfig) {
+        ipfsPath = ipfsPathConfig
+      } else {
+        ipfsPath = Path.join(os.homedir(), '.ipfs-3speak_v0.16.0') // Use the default path if no folder is selected
+      }
     }
 
     let exists
@@ -197,7 +226,7 @@ export class IpfsHandler {
             }*/
     }
 
-    let isRunning = false;
+    let isRunning = false
     if (apiAddr) {
       ipfs = IPFSHTTPClient.create({ url: IPFS_HOST })
       try {
@@ -213,7 +242,6 @@ export class IpfsHandler {
     }
 
     if (ipfs !== null && isRunning) {
-      
       const gma = await ipfs.config.get('Addresses.Gateway')
       gateway = toUri(gma) + '/ipfs/'
     } else {


### PR DESCRIPTION
On the first boot of the app the user will be asked what folder should be chosen for IPFS pins.

If nothing is chosen it will fallback to the default.

It is set on the config file, that by default does not have a path:
![image](https://github.com/spknetwork/3Speak-app/assets/21374091/4c6094f5-e0fc-4021-91f5-8b925484956a)

The fallback default folder is `.ipfs-3speak_v0.16.0/`

On the first boot the default folder is expected to not exist, the user will be then asked what should be the folder to store IPFS pins:
![image](https://github.com/spknetwork/3Speak-app/assets/21374091/08bd92e9-5837-4af9-952c-eec103e5bb36)

If I choose a custom folder `test` then the folder will be initiated by IPFS and saved to config:
![image](https://github.com/spknetwork/3Speak-app/assets/21374091/51fc3956-ec5f-4aa4-8e26-563c53e03746)


If no folder is chosen it will then fallback to `.ipfs-3speak_v0.16.0/` and similarly save on the config file. 